### PR TITLE
Week1 Day1 - baseline execution, diagnostics, and minimal fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ nosetests.xml
 venv
 app.db
 blog.log*
+
+.venv/

--- a/day1_app_start.log
+++ b/day1_app_start.log
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "/workspace/flask_app/app.py", line 8, in <module>
+    from flask import render_template, g
+ModuleNotFoundError: No module named 'flask'

--- a/day1_pip_install.log
+++ b/day1_pip_install.log
@@ -1,0 +1,7 @@
+WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/alembic/
+WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/alembic/
+WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/alembic/
+WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/alembic/
+WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))': /simple/alembic/
+ERROR: Could not find a version that satisfies the requirement alembic==0.9.5 (from versions: none)
+ERROR: No matching distribution found for alembic==0.9.5

--- a/day1_summary.md
+++ b/day1_summary.md
@@ -1,0 +1,19 @@
+# Week1 Day1 Summary
+
+## 执行概览
+- 已创建虚拟环境：`.venv`
+- 依赖安装失败：网络代理返回 `403 Forbidden`，无法从 PyPI 拉取依赖
+- 应用启动失败：由于 `flask` 未安装触发 `ModuleNotFoundError`
+
+## 关键错误摘要
+1. `pip install -r requirements.txt` 失败：
+   - `ERROR: Could not find a version that satisfies the requirement alembic==0.9.5`
+   - `ERROR: No matching distribution found for alembic==0.9.5`
+2. `python app.py` 失败：
+   - `ModuleNotFoundError: No module named 'flask'`
+
+## 阻塞判定
+- 当前为**环境阻塞**（外网包源不可达 / 代理拒绝），非业务代码阻塞。
+
+## 建议
+- 修复网络/代理后重试依赖安装，再执行应用启动验证。

--- a/docs/week1-day1.md
+++ b/docs/week1-day1.md
@@ -1,0 +1,38 @@
+# Week1 Day1 - Baseline Execution & Diagnostics
+
+## 1) 执行命令
+在仓库根目录 `/workspace/flask_app` 执行：
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip setuptools wheel
+pip install -r requirements.txt 2>&1 | tee day1_pip_install.log
+
+export DB_URI='mysql+pymysql://user:pass@127.0.0.1:3306/blog'
+export MAIL_SERVER='smtp.example.com'
+export MAIL_USERNAME='noreply@example.com'
+export MAIL_PASSWORD='replace_me'
+export ADMINS='admin@example.com'
+
+timeout 30s python app.py 2>&1 | tee day1_app_start.log || true
+rg -n "Traceback|ERROR|Exception|ModuleNotFoundError|ImportError|OperationalError" day1_pip_install.log day1_app_start.log || true
+```
+
+## 2) 结果状态
+- 状态：**配置 + 依赖阻塞**（尚不可启动）
+- 说明：`pip` 无法从包源获取依赖，导致 Flask 未安装，应用无法启动。
+
+## 3) 错误摘要
+- 依赖安装日志（`day1_pip_install.log`）中出现：
+  - `ERROR: Could not find a version that satisfies the requirement alembic==0.9.5`
+  - `ERROR: No matching distribution found for alembic==0.9.5`
+- 启动日志（`day1_app_start.log`）中出现：
+  - `ModuleNotFoundError: No module named 'flask'`
+
+## 4) 下一步建议（Day2 输入）
+1. 优先修复构建网络：
+   - 检查 CI/容器代理配置（当前返回 `Tunnel connection failed: 403 Forbidden`）。
+   - 切换到可访问镜像源后重新安装 `requirements.txt`。
+2. 依赖可安装后，重新执行 Day1 启动命令，确认 Flask App 可拉起。
+3. 若启动后出现 DB 连接失败，再区分为外部依赖阻塞（MySQL/Redis）并补充最小连通性验证。


### PR DESCRIPTION
## What changed
- Created a Python virtual environment baseline (`.venv`) and attempted dependency bootstrap.
- Captured dependency installation output in `day1_pip_install.log`.
- Exported minimal runtime env vars and attempted app startup with timeout; captured output in `day1_app_start.log`.
- Added `day1_summary.md` with key failure analysis and blocker classification.
- Added `docs/week1-day1.md` documenting commands, status, errors, and Day2 recommendations.
- Updated `.gitignore` to ignore `.venv/`.

## Why
Day1 requires a reproducible baseline execution attempt with traceable diagnostics and clear next-step handoff. The run identified environment-level dependency acquisition failures that prevent application startup.

## Risks
- Logs include environment-level failure details (proxy/packaging errors) that may vary by execution environment.
- No application-code behavior was validated beyond import stage due to unmet dependencies.

## How to verify
1. In `/workspace/flask_app`, review generated artifacts:
   - `day1_pip_install.log`
   - `day1_app_start.log`
   - `day1_summary.md`
   - `docs/week1-day1.md`
2. Confirm error extraction:
   - `rg -n "Traceback|ERROR|Exception|ModuleNotFoundError|ImportError|OperationalError" day1_pip_install.log day1_app_start.log`
3. After fixing package network access, rerun install/start commands documented in `docs/week1-day1.md`.

## Day2 recommended actions
1. Fix package egress/proxy (current tunnel returns `403 Forbidden`) so `pip install -r requirements.txt` can complete.
2. Re-run startup to move past import stage.
3. If startup then fails on MySQL/Redis connectivity, classify as external dependency blocker and add service-level connectivity checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4557776883258767ad76e6b58682)